### PR TITLE
Update README - Correct module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@
 **JS Library**
 
 ```sh
-yarn add 'oa'
+yarn add 'lib-oa'
 ```
 
 **CLI**
 
 ```sh
-yarn global add 'oa'
+yarn global add 'lib-oa'
 ```
 
 <h3 align=center>Instantiation</h3>
@@ -28,7 +28,7 @@ Alternatively an API token can be provided via a `OA_TOKEN` environment variable
 **JS Library**
 
 ```js
-const OA = require('oa');
+const OA = require('lib-oa');
 
 const oa = new OA({
     username: 'ingalls',


### PR DESCRIPTION
The `package.json` name is `lib-oa`, I think this might have been renamed at some point.
I confused this module with https://www.npmjs.com/package/oa which exports a different public API