### PR TITLE
deps: minimist is a runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
     "license": "MIT",
     "dependencies": {
         "inquirer": "^8.0.0",
+        "minimist": "^1.2.5",
         "request": "^2.88.2"
     },
     "devDependencies": {
         "asciichart": "^1.5.25",
         "eslint": "^7.24.0",
-        "eslint-plugin-node": "^11.1.0",
-        "minimist": "^1.2.5"
+        "eslint-plugin-node": "^11.1.0"
     }
 }


### PR DESCRIPTION
```bash
/tmp ❯ node example.js
internal/modules/cjs/loader.js:905
  throw err;
  ^

Error: Cannot find module 'minimist'
Require stack:
- /private/tmp/node_modules/lib-oa/oa.js
- /private/tmp/example.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:902:15)
    at Function.Module._load (internal/modules/cjs/loader.js:746:27)
    at Module.require (internal/modules/cjs/loader.js:974:19)
    at require (internal/modules/cjs/helpers.js:93:18)
    at Object.<anonymous> (/private/tmp/node_modules/lib-oa/oa.js:11:14)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:12)
    at Module.require (internal/modules/cjs/loader.js:974:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/private/tmp/node_modules/lib-oa/oa.js',
    '/private/tmp/example.js'
  ]
}
```