### PR TITLE
Add cleanup API routes to schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@openaddresses/lib",
     "type": "module",
-    "version": "4.4.5",
+    "version": "4.5.0",
     "main": "oa.js",
     "repository": "git@github.com:openaddresses/lib",
     "author": "ingalls <nick@ingalls.ca>",

--- a/src/schema.json
+++ b/src/schema.json
@@ -58,7 +58,8 @@
                 "update": "PATCH /run/:run",
                 "get": "GET /run/:run",
                 "jobs": "GET /run/:run/jobs",
-                "jobs_count": "GET /run/:run/count"
+                "jobs_count": "GET /run/:run/count",
+                "delete": "DELETE /run/:run"
             }
         },
         "job": {
@@ -75,7 +76,9 @@
                 "sample": "GET /job/:job/output/sample",
                 "cache": "GET /job/:job/output/cache.zip",
                 "log": "GET /job/:job/log",
-                "raw": "GET /job/:job/raw"
+                "raw": "GET /job/:job/raw",
+                "delete": "DELETE /job/:job",
+                "orphaned": "GET /job/orphaned"
             }
         },
         "joberror": {
@@ -303,6 +306,16 @@
             "query": false,
             "res": true
         },
+        "DELETE /job/:job": {
+            "body": false,
+            "query": false,
+            "res": true
+        },
+        "GET /job/orphaned": {
+            "body": false,
+            "query": true,
+            "res": true
+        },
         "GET /level": {
             "body": false,
             "query": true,
@@ -414,6 +427,11 @@
             "res": true
         },
         "GET /run/:run/jobs": {
+            "body": false,
+            "query": false,
+            "res": true
+        },
+        "DELETE /run/:run": {
             "body": false,
             "query": false,
             "res": true


### PR DESCRIPTION
## Summary
- Add `DELETE /job/:job` and `GET /job/orphaned` to job CLI commands and schema
- Add `DELETE /run/:run` to run CLI commands and schema
- Bump version to 4.5.0

These routes support the new cleanup task in openaddresses/batch.